### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -123,6 +123,6 @@ defmodule Ueberauth.Strategy.Auth0 do
   end
 
   defp option(conn, key) do
-    Dict.get(options(conn), key, Dict.get(default_options, key))
+    Keyword.get(options(conn), key, Keyword.get(default_options(), key))
   end
 end

--- a/lib/ueberauth/strategy/auth0/oauth.ex
+++ b/lib/ueberauth/strategy/auth0/oauth.ex
@@ -57,9 +57,9 @@ defmodule Ueberauth.Strategy.Auth0.OAuth do
   def get_token!(params \\ [], opts \\ %{}) do
     client_secret = options()[:client_secret]
     params = Keyword.merge(params, client_secret: client_secret)
-    headers = Dict.get(opts, :headers, [])
-    opts = Dict.get(opts, :options, [])
-    client_options = Dict.get(opts, :client_options, [])
+    headers = Map.get(opts, :headers, [])
+    opts = Map.get(opts, :options, [])
+    client_options = Map.get(opts, :client_options, [])
     OAuth2.Client.get_token!(client(client_options), params, headers, opts)
   end
 


### PR DESCRIPTION
- Replace `Dict` with `Map` and `Keyword`
- Add missing parentheses for zero-arity function calls