### PR TITLE
Add support for per-app config

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -35,7 +35,10 @@ defmodule Ueberauth.Strategy.Auth0 do
     opts = [scope: scopes]
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
     module = option(conn, :oauth2_module)
-    callback_url = apply(module, :authorize_url!, [opts])
+    callback_url = apply(module, :authorize_url!, [
+      opts,
+      [otp_app: option(conn, :otp_app)]
+    ])
     redirect!(conn, callback_url)
   end
 
@@ -47,7 +50,8 @@ defmodule Ueberauth.Strategy.Auth0 do
     module = option(conn, :oauth2_module)
     redirect_uri = callback_url(conn)
     client = apply(module, :get_token!, [
-      [code: code, redirect_uri: redirect_uri]
+      [code: code, redirect_uri: redirect_uri],
+      [otp_app: option(conn, :otp_app)]
     ])
     token = client.token
     if token.access_token == nil do


### PR DESCRIPTION
Why:

* Now that Ueberauth version 0.6+ supports per-app configuration, we'd
  like to update uberauth_auth0 strategy to support per-app
  configuration also.

  We'd like to config our apps like this, in our configuration file
  (config/config.exs):
  ```
  # Configures Ueberauth
  config :my_app, Ueberauth,
    providers: [
      auth0: {Ueberauth.Strategy.Auth0, [otp_app: :my_app]}
    ]
  ```

  and to use `Ueberauth` from a controller like this:
  ```
  plug Ueberauth, otp_app: :my_app
  ```

* Issue link: n/a

This change addresses the need by:

* Editing `Ueberauth.Strategy.Auth0.handle_request!/1` and
  `Ueberauth.Strategy.Auth0.handle_callback!/1` to pass along the
  configured `:otp_app`, found in the `conn`, to a function that needs
  it in the body of these two functions.
* Editing `Ueberauth.Strategy.Auth0.OAuth` to get config from `otp_app`
  when an `otp_app` is provided to `authorize_url!/2` and
  `get_token!/2`.