### PR TITLE
Fix warning about coveralls not needing quotes.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule UeberauthAuth0.Mixfile do
       # Test coverage:
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
-        "coveralls": :test,
+        coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test,


### PR DESCRIPTION
When using ueberauth_auth0 in a project, the below warning is emitted.
This PR clears the warning.

```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of Unicode letters, numbers, underscore, and @ do not require quotes
  project_root/deps/ueberauth_auth0/mix.exs:25
```