### PR TITLE
Parse scopes as space delimited from token response

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -205,7 +205,7 @@ defmodule Ueberauth.Strategy.Auth0 do
 
     scopes =
       (token.other_params["scope"] || "")
-      |> String.split(",")
+      |> String.split(" ")
 
     %Credentials{
       token: token.access_token,

--- a/test/fixtures/vcr_cassettes/auth0-ok-response.json
+++ b/test/fixtures/vcr_cassettes/auth0-ok-response.json
@@ -14,7 +14,7 @@
     },
     "response": {
       "binary": false,
-      "body": "{\"access_token\":\"eyJz93alolk4laUWw\",\"refresh_token\":\"GEbRxBNkitedjnXbL\",\"id_token\":\"eyJ0XAipop4faeEoQ\",\"token_type\":\"Bearer\",\"expires_in\":86400}",
+      "body": "{\"access_token\":\"eyJz93alolk4laUWw\",\"refresh_token\":\"GEbRxBNkitedjnXbL\",\"id_token\":\"eyJ0XAipop4faeEoQ\",\"token_type\":\"Bearer\",\"expires_in\":86400,\"scope\":\"openid profile email\"}",
       "headers": {
         "Date": "Wed, 17 Jun 2020 23:39:36 GMT",
         "Content-Type": "application/json",

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -124,6 +124,7 @@ defmodule Ueberauth.Strategy.Auth0Test do
       ## Tokens have expiration time (see other test below)
       assert auth.credentials.expires == true
       assert is_integer(auth.credentials.expires_at)
+      assert auth.credentials.scopes == ["openid", "profile", "email"]
     end
   end
 


### PR DESCRIPTION
The scopes returned in the token response were space-delimited, so the `String.split/3` wasn't creating the list as expected. 

This is will break client code depending on a single item list though, should it be configurable?

Addresses #232 